### PR TITLE
Resolved mismatch stubbings in HeaderFooterFilterTest.java

### DIFF
--- a/src/test/java/org/jasig/portlet/proxy/service/proxy/document/HeaderFooterFilterTest.java
+++ b/src/test/java/org/jasig/portlet/proxy/service/proxy/document/HeaderFooterFilterTest.java
@@ -61,6 +61,7 @@ public class HeaderFooterFilterTest {
 
 	@Test
 	public void addHeader() {
+		when(preferences.getValue("footerHtml", null)).thenReturn(null);
 		String header = "<div>A header</div>";
 		when(preferences.getValue(HeaderFooterFilter.HEADER_KEY, null)).thenReturn(header);
 	
@@ -72,6 +73,7 @@ public class HeaderFooterFilterTest {
 	@Test
 	public void addFooter() {
 		
+		when(preferences.getValue("headerHtml", null)).thenReturn(null);
 		String footer = "<div>A footer</div>";
 		when(preferences.getValue(HeaderFooterFilter.FOOTER_KEY, null)).thenReturn(footer);
 		


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `addHeader`: 
* the `getValue` method for the `preferences` object:
i) during test execution the method is actually called with arguments `["footerHtml", null]`, but is not stubbed, resulting in a mismatch stubbing. 

In the test `addFooter`: 
* the `getValue` method for the `preferences` object:
i) during test execution the method is actually called with arguments `["headerHtml", null]`, but is not stubbed, resulting in a mismatch stubbing. 

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.