### PR TITLE
Resolved mismatch stubbings in MultiRequestHttpClientServiceImplTest.java

### DIFF
--- a/src/test/java/org/jasig/portlet/proxy/service/web/MultiRequestHttpClientServiceImplTest.java
+++ b/src/test/java/org/jasig/portlet/proxy/service/web/MultiRequestHttpClientServiceImplTest.java
@@ -49,9 +49,6 @@ public class MultiRequestHttpClientServiceImplTest {
 		
 		when(request.getPreferences()).thenReturn(preferences);
 		when(request.getPortletSession()).thenReturn(session);
-		when(preferences.getValue(MultiRequestHttpClientServiceImpl.HTTP_CLIENT_CONNECTION_TIMEOUT,
-				String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT)))
-				.thenReturn(String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT));
 		when(preferences.getValue(MultiRequestHttpClientServiceImpl.HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT,
 				String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT)))
 				.thenReturn(String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT));
@@ -63,6 +60,10 @@ public class MultiRequestHttpClientServiceImplTest {
 	
 	@Test
 	public void testGetSharedClient() {
+		when(preferences.getValue(MultiRequestHttpClientServiceImpl.HTTP_CLIENT_CONNECTION_TIMEOUT,
+				String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT)))
+				.thenReturn(String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT));
+		when(session.getAttribute("org.springframework.web.util.WebUtils.MUTEX", 1)).thenReturn(null);
 		when(preferences.getValue(MultiRequestHttpClientServiceImpl.SHARED_SESSION_KEY, null)).thenReturn("sharedSession");
 		when(session.getAttribute("sharedSession", PortletSession.APPLICATION_SCOPE)).thenReturn(client);
 		
@@ -72,6 +73,8 @@ public class MultiRequestHttpClientServiceImplTest {
 	
 	@Test
 	public void testGetUnsharedClient() {
+		when(preferences.getValue("sharedSessionKey", null)).thenReturn(null);
+		when(session.getAttribute("org.springframework.web.util.WebUtils.MUTEX", 1)).thenReturn(null);
 		when(session.getAttribute(MultiRequestHttpClientServiceImpl.CLIENT_SESSION_KEY, PortletSession.PORTLET_SCOPE)).thenReturn(client);
 		
 		HttpClient response = service.getHttpClient(request);
@@ -80,6 +83,9 @@ public class MultiRequestHttpClientServiceImplTest {
 	
 	@Test
 	public void testCreateSharedClient() {
+		when(preferences.getValue(MultiRequestHttpClientServiceImpl.HTTP_CLIENT_CONNECTION_TIMEOUT,
+				String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT)))
+				.thenReturn(String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT));
 		when(preferences.getValue(MultiRequestHttpClientServiceImpl.SHARED_SESSION_KEY, null)).thenReturn("sharedSession");
 		HttpClient response = service.getHttpClient(request);
 		assertNotNull(response);
@@ -88,6 +94,10 @@ public class MultiRequestHttpClientServiceImplTest {
 	
 	@Test
 	public void testCreateUnsharedClient() {
+		when(preferences.getValue(MultiRequestHttpClientServiceImpl.HTTP_CLIENT_CONNECTION_TIMEOUT,
+				String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT)))
+				.thenReturn(String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT));
+		when(preferences.getValue("sharedSessionKey", null)).thenReturn(null);
 		HttpClient response = service.getHttpClient(request);
 		assertNotNull(response);
 		verify(session).setAttribute(MultiRequestHttpClientServiceImpl.CLIENT_SESSION_KEY, response, PortletSession.PORTLET_SCOPE);


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `testGetSharedClient`:
* the `getAttribute` method for the `session` object:
i) during test execution the method is actually called with arguments `["org.springframework.web.util.WebUtils.MUTEX", 1]`, but is not stubbed, resulting in a mismatch stubbing.

In the test `testGetUnsharedClient`:
* the `getValue` method for the `preferences` object:
i) is stubbed in the `setUp` method with arguments `[MultiRequestHttpClientServiceImpl.HTTP_CLIENT_CONNECTION_TIMEOUT, String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT)]`
ii) during test execution the method is actually called with arguments `["sharedSessionKey", null]`, resulting in a mismatch stubbing
* the `getAttribute` method for the `session` object:
i) during test execution the method is actually called with arguments `["org.springframework.web.util.WebUtils.MUTEX", 1]`, but is not stubbed, resulting in a mismatch stubbing.

In the test `testCreateUnsharedClient`:
* the `getValue` method for the `preferences` object:
i) during test execution the method is actually called with arguments `["sharedSessionKey", null]`, but is not stubbed, resulting in a mismatch stubbing.

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.