### PR TITLE
Resolved mismatch stubbings in HttpContentServiceImplTest.java

### DIFF
--- a/src/test/java/org/jasig/portlet/proxy/service/web/HttpContentServiceImplTest.java
+++ b/src/test/java/org/jasig/portlet/proxy/service/web/HttpContentServiceImplTest.java
@@ -53,6 +53,7 @@ public class HttpContentServiceImplTest {
 		when(request.getPreferences()).thenReturn(preferences);
   		when(preferences.getValue(GenericContentRequestImpl.CONTENT_LOCATION_PREFERENCE, null)).thenReturn("http://somewhere.com/path/page.html");
 
+		when(request.getParameter("proxy.url")).thenReturn(null);
 	}
 
 
@@ -103,6 +104,7 @@ public class HttpContentServiceImplTest {
 	@Test
 	public void testNonForm() {
 
+		when(request.getParameter("proxy.formMethod")).thenReturn(null);
 		when(request.getParameter(HttpContentServiceImpl.IS_FORM_PARAM)).thenReturn("false");
 		when(processor.process(any(String.class), any(PortletRequest.class))).thenReturn("http://somewhere.com/path/page.html");
 		HttpContentRequestImpl proxyRequest = new HttpContentRequestImpl(request, processor);


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In tests `testPostFormNoParams`, `testGetForm`, and `testGetFormNoParams`: 
* the `getParameter` method for the `request` object:
i) during test execution the method is actually called with argument `"proxy.url"`, but is not stubbed, resulting in mismatch stubbings. 

In the test `testNonForm`: 
* the `getParameter` method for the `request` object:
i) during test execution the method is actually called with argument `"proxy.url"`, but is not stubbed, resulting in mismatch stubbings. 
ii) during test execution the method is actually called with argument `"proxy.formMethod"`, but is not stubbed, resulting in another mismatch stubbing. 

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.